### PR TITLE
Add definitions for ttt2 and ttt3 in `fundarg.m`

### DIFF
--- a/software/matlab/fundarg.m
+++ b/software/matlab/fundarg.m
@@ -45,6 +45,9 @@ function [ l, l1, f, d, omega, ...
         % arcsec to deg
         oo3600 = 1.0 / 3600.0;
 
+        ttt2 = ttt * ttt;
+        ttt3 = ttt2 * ttt;
+
         % ---- determine coefficients for iau 2000 nutation theory ----
         % ---- iau 2006 theory
         if opt == '06'


### PR DESCRIPTION
`ttt2` is referenced in the `'96'` model but not defined (`ttt3` seems to be unused but added it anyway due to header)