### PR TITLE
feat: add rotation matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .ipynb_checkpoints/
 __pycache__/
 .coverage
+/venv

--- a/software/python/src/valladopy/mathtime/vector.py
+++ b/software/python/src/valladopy/mathtime/vector.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 from ..constants import SMALL
 
@@ -18,7 +19,7 @@ from ..constants import SMALL
 def rot1(vec, xval):
     """Rotation about the 1st axis (x-axis)
 
-    Inputs:
+    Args:
         vec (array_like): Input vector
         xval (float): Angle of rotation in radians
 
@@ -39,7 +40,7 @@ def rot1(vec, xval):
 def rot2(vec, xval):
     """Rotation about the 2nd axis (y-axis)
 
-    Inputs:
+    Args:
         vec (array_like): Input vector
         xval (float): Angle of rotation in radians
 
@@ -60,7 +61,7 @@ def rot2(vec, xval):
 def rot3(vec, xval):
     """Rotation about the 3rd axis (z-axis)
 
-    Inputs:
+    Args:
         vec (array_like): Input vector
         xval (float): Angle of rotation in radians
 
@@ -76,6 +77,77 @@ def rot3(vec, xval):
         ]
     )
     return outvec
+
+
+###############################################################################
+# Rotation Matrices
+###############################################################################
+
+def rot1mat(xval: float) -> ArrayLike:
+    """Rotation matrix for an input angle about the first axis.
+    Assume: Use of "column" vectors
+    
+    Args:
+        xval (float): Angle of rotation in radians
+    
+    Returns:
+        outmat (array_like): Rotation matrix
+    """
+    c, s = np.cos(xval), np.sin(xval)
+
+    outmat = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, c, -s],
+            [0.0, s, c]
+        ]
+    )
+
+    return outmat
+
+def rot2mat(xval: float) -> ArrayLike:
+    """Rotation matrix for an input angle about the second axis.
+    Assume: Use of "column" vectors
+    
+    Args:
+        xval (float): Angle of rotation in radians
+    
+    Returns:
+        outmat (array_like): Rotation matrix
+    """
+    c, s = np.cos(xval), np.sin(xval)
+
+    outmat = np.array(
+        [
+            [c, 0.0, s],
+            [0.0, 1.0, 0.0],
+            [-s, 0.0, c]
+        ]
+    )
+
+    return outmat
+
+def rot3mat(xval: float) -> ArrayLike:
+    """Rotation matrix for an input angle about the third axis.
+    Assume: Use of "column" vectors
+    
+    Args:
+        xval (float): Angle of rotation in radians
+    
+    Returns:
+        outmat (array_like): Rotation matrix
+    """
+    c, s = np.cos(xval), np.sin(xval)
+
+    outmat = np.array(
+        [
+            [c, -s, 0.0],
+            [s, c, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+    return outmat
 
 
 ###############################################################################

--- a/software/python/tests/mathtime/test_vector.py
+++ b/software/python/tests/mathtime/test_vector.py
@@ -3,6 +3,9 @@ import pytest
 
 import src.valladopy.mathtime.vector as vec
 
+###############################################################################
+# Axes Rotations
+###############################################################################
 
 @pytest.mark.parametrize(
     'func, angle, vector, expected',
@@ -18,6 +21,70 @@ import src.valladopy.mathtime.vector as vec
 def test_rotations(func, angle, vector, expected):
     assert np.allclose(func(vector, angle), expected, rtol=1e-12)
 
+
+###############################################################################
+# Rotation Matrices
+###############################################################################
+
+@pytest.mark.parametrize(
+    'func, angle, expected',
+    [
+        (
+            vec.rot1mat,
+            np.pi / 2,
+            np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]),
+        ),
+        (
+            vec.rot2mat,
+            np.pi / 2,
+            np.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]]),
+        ),
+        (
+            vec.rot3mat,
+            np.pi / 2,
+            np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        ),
+        (
+            vec.rot1mat,
+            np.pi / 4,
+            np.array(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1 / np.sqrt(2), -1 / np.sqrt(2)],
+                    [0.0, 1 / np.sqrt(2), 1 / np.sqrt(2)],
+                ]
+            ),
+        ),
+        (
+            vec.rot2mat,
+            np.pi / 4,
+            np.array(
+                [
+                    [1 / np.sqrt(2), 0.0, 1 / np.sqrt(2)],
+                    [0.0, 1.0, 0],
+                    [-1 / np.sqrt(2), 0.0, 1 / np.sqrt(2)],
+                ]
+            ),
+        ),
+        (
+            vec.rot3mat,
+            np.pi / 4,
+            np.array(
+                [
+                    [1 / np.sqrt(2), -1 / np.sqrt(2), 0.0],
+                    [1 / np.sqrt(2), 1 / np.sqrt(2), 0],
+                    [0.0, 0.0, 1.0],
+                ]
+            ),
+        ),
+    ],
+)
+def test_rotation_matrices(func, angle, expected):
+    assert np.allclose(func(angle), expected, rtol=1e-12)
+
+###############################################################################
+# Vector Math
+###############################################################################
 
 @pytest.mark.parametrize(
     'v1, v2, expected_angle',


### PR DESCRIPTION
- Incorporated python counterparts of `rot1mat, rot2mat, rot3mat`, along with their tests. (`rot1mat, rot2mat, rot3mat` are setup for column vectors, as opposed to row vectors in their corresponding MATLAB implementations.)
- Modified `Inputs` to `Args` in docstrings of `vector.py` for consistency 
- Added `venv` to `.gitignore`