### PR TITLE
Bugfix: Update  to set times correctly based on typerun

### DIFF
--- a/software/matlab/twoline2rv.m
+++ b/software/matlab/twoline2rv.m
@@ -201,6 +201,19 @@
     [mon,day,hr,minute,sec] = days2mdh ( year,satrec.epochdays );
     [satrec.jdsatepoch, satrec.jdsatepochf] = jday( year,mon,day,hr,minute,sec );
 
+    % perform complete catalog evaluation
+    if (typerun == 'c')
+        startmfe =  -1440.0;
+        stopmfe  =  1440.0;
+        deltamin = 20.0;
+    end
+    % user input
+    if (typerun == 'u')
+        startmfe =  0.0;
+        stopmfe  =  14400.0;
+        deltamin = 1440.0;
+    end
+
     %     // input start stop times manually
     if ((typerun ~= 'v') && (typerun ~= 'c')  && (typerun ~= 'u'))
         % ------------- enter start/stop ymd hms values --------------------
@@ -247,19 +260,6 @@
             stopmfe  = input('input stop mfe: ');
             deltamin = input('input time step in minutes: ');
         end
-    end
-
-    % perform complete catalog evaluation
-    if (typerun == 'c')
-        startmfe =  -1440.0;
-        stopmfe  =  1440.0;
-        deltamin = 20.0;
-    end
-    % user input
-    if (typerun == 'u')
-        startmfe =  0.0;
-        stopmfe  =  14400.0;
-        deltamin = 1440.0;
     end
 
     %     // ------------- initialize the orbit at sgp4epoch --------------


### PR DESCRIPTION
2 fixes:

1. The default values for `startmfe`, `stopmfe`, and `deltamin` are currently defined after they are updated for the case where they are defined for when `typerun == 'v'`, which means those values get overwritten by the default values - the fix is to define those default values at the very top so that when `typerun == 'v'`, it can extract those values from the 2nd line of the TLE

2. There is a block to input times manually (under `if ((typerun ~= 'v') && (typerun ~= 'c')  && (typerun ~= 'u'))`), but under this block are the blocks to set the times for when `if (typerun == 'c')` and `if (typerun == 'u')`, which will never get reached - the fix is to move those blocks outside the `if` check for inputting manual times