### PR TITLE
Recalculate `sineo1` and `coseo1` after kepler iteration in `sgp4.m`

### DIFF
--- a/software/matlab/sgp4.m
+++ b/software/matlab/sgp4.m
@@ -271,6 +271,8 @@ function [satrec, r, v] = sgp4(satrec, tsince);
    end
 
    % /* ------------- short period preliminary quantities ----------- */
+   sineo1 = sin(eo1);
+   coseo1 = cos(eo1);
    ecose = axnl*coseo1 + aynl*sineo1;
    esine = axnl*sineo1 - aynl*coseo1;
    el2   = axnl*axnl + aynl*aynl;


### PR DESCRIPTION
This is a really small correction, where the kepler iteration updates `sineo1` and `coseo1` at the start of the iteration, but `eo1` is updated at the end:

```
   while (( abs(tem5) >= 1.0e-12) && (ktr <= 10) )
       sineo1 = sin(eo1);
       coseo1 = cos(eo1);
       tem5   = 1.0 - coseo1 * axnl - sineo1 * aynl;
       tem5   = (u - aynl * coseo1 + axnl * sineo1 - eo1) / tem5;
       if(abs(tem5) >= 0.95)
           if tem5 > 0.0
               tem5 = 0.95;
           else
               tem5 = -0.95;
           end
       end
       eo1    = eo1 + tem5;
       ktr = ktr + 1;
   end
```

which means that the final sine/cosine of `eo1` is not up to date when it finally exits from the `while` loop, so just adding a recalculation of these terms after the iteration