### PR TITLE
fix: Invalid sscanf argument

### DIFF
--- a/software/cpp/SGP4/SGP4/SGP4.cpp
+++ b/software/cpp/SGP4/SGP4/SGP4.cpp
@@ -2237,11 +2237,11 @@ namespace SGP4Funcs
 			longstr1[68] = '0';
 #ifdef _MSC_VER // chk if compiling in MSVS c++
 		sscanf_s(longstr1, "%2d %5s %1c %10s %2d %12lf %11lf %7lf %2d %7lf %2d %2d %6ld ",
-			&cardnumb, &satrec.satnumStr, 6 * sizeof(char), &satrec.classification, sizeof(char), &satrec.intldesg, 11 * sizeof(char), &satrec.epochyr,
+			&cardnumb, satrec.satnumStr, 6 * sizeof(char), &satrec.classification, sizeof(char), satrec.intldesg, 11 * sizeof(char), &satrec.epochyr,
 			&satrec.epochdays, &satrec.ndot, &satrec.nddot, &nexp, &satrec.bstar, &ibexp, &satrec.ephtype, &satrec.elnum);
 #else
 		sscanf(longstr1, "%2d %5s %1c %10s %2d %12lf %11lf %7lf %2d %7lf %2d %2d %6ld ",
-			&cardnumb, &satrec.satnumStr, &satrec.classification, &satrec.intldesg, &satrec.epochyr,
+			&cardnumb, satrec.satnumStr, &satrec.classification, satrec.intldesg, &satrec.epochyr,
 			&satrec.epochdays, &satrec.ndot, &satrec.nddot, &nexp, &satrec.bstar,
 			&ibexp, &satrec.ephtype, &satrec.elnum);
 #endif
@@ -2268,12 +2268,12 @@ namespace SGP4Funcs
 				{
 #ifdef _MSC_VER
 					sscanf_s(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %10lf %6ld %lf %lf %lf \n",
-						&cardnumb, &satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
+						&cardnumb, satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum, &startmfe, &stopmfe, &deltamin);
 #else
 					sscanf(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %10lf %6ld %lf %lf %lf \n",
-						&cardnumb, &satrec.satnumStr, &satrec.inclo,
+						&cardnumb, satrec.satnumStr, &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum, &startmfe, &stopmfe, &deltamin);
 #endif
@@ -2282,12 +2282,12 @@ namespace SGP4Funcs
 				{
 #ifdef _MSC_VER
 					sscanf_s(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %10lf %6ld \n",
-						&cardnumb, &satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
+						&cardnumb, satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum);
 #else
 					sscanf(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %10lf %6ld \n",
-						&cardnumb, &satrec.satnumStr, &satrec.inclo,
+						&cardnumb, satrec.satnumStr, &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum);
 #endif
@@ -2298,12 +2298,12 @@ namespace SGP4Funcs
 				{
 #ifdef _MSC_VER
 					sscanf_s(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %11lf %6ld %lf %lf %lf \n",
-						&cardnumb, &satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
+						&cardnumb, satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum, &startmfe, &stopmfe, &deltamin);
 #else
 					sscanf(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %11lf %6ld %lf %lf %lf \n",
-						&cardnumb, &satrec.satnumStr, &satrec.inclo,
+						&cardnumb, satrec.satnumStr, &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum, &startmfe, &stopmfe, &deltamin);
 #endif
@@ -2312,12 +2312,12 @@ namespace SGP4Funcs
 				{
 #ifdef _MSC_VER
 					sscanf_s(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %11lf %6ld \n",
-						&cardnumb, &satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
+						&cardnumb, satrec.satnumStr, 6 * sizeof(char), &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum);
 #else
 					sscanf(longstr2, "%2d %5s %9lf %9lf %8lf %9lf %9lf %11lf %6ld \n",
-						&cardnumb, &satrec.satnumStr, &satrec.inclo,
+						&cardnumb, satrec.satnumStr, &satrec.inclo,
 						&satrec.nodeo, &satrec.ecco, &satrec.argpo, &satrec.mo, &satrec.no_kozai,
 						&satrec.revnum);
 #endif


### PR DESCRIPTION
## Summary
 
Remove unnecessary `&` in front of `satnumStr` and `intldesg` arguments since these are already pointers.

Closes #164 

## Changes

The bug: `satnumStr (char[6])` and `intldesg (char[11])` are C arrays, which already decay to `char*` when passed as arguments. Writing `&satrec.satnumStr` produces a `char (*)[6]` (pointer-to-array), which is the wrong type for `sscanf`/`sscanf_s` and technically undefined behavior. The address value happens to be the same, so it may work on most platforms, but is still incorrect.                                
                                                                                                                                                                                                         
Fix: Removed `&` from `satrec.satnumStr` and `satrec.intldesg` in all 10 affected `sscanf`/`sscanf_s` calls.

## Testing

N/A - fix is a type-correctness change and  the numeric address is unchanged

## Language(s) Affected

- [ ] Python
- [ ] MATLAB
- [ ] C#
- [x] C++
- [ ] Fortran
- [ ] Documentation only
