### PR TITLE
hotfix: update covariance tolerances to be looser

### DIFF
--- a/software/python/tests/astro/iod/test_utils.py
+++ b/software/python/tests/astro/iod/test_utils.py
@@ -40,4 +40,4 @@ def test_hgibbs():
     assert np.allclose(v2, v2_expected, rtol=DEFAULT_TOL)
     assert np.isclose(np.degrees(theta12), 4.499996147374992, rtol=DEFAULT_TOL)
     assert np.isclose(np.degrees(theta23), 4.499998402168982, rtol=DEFAULT_TOL)
-    assert custom_isclose(float(np.degrees(copa)), -2.6712072741804056e-06)
+    assert custom_isclose(float(np.degrees(copa)), -2.6712072741804056e-06, rtol=1e-9)

--- a/software/python/tests/astro/twobody/covariance/test_frame_conversion.py
+++ b/software/python/tests/astro/twobody/covariance/test_frame_conversion.py
@@ -6,6 +6,10 @@ from src.valladopy.astro.time.data import iau80in
 
 from ....conftest import custom_allclose
 
+# Covariance frame conversions accumulate numerical error across numpy/BLAS versions;
+# these tests need wider tolerance than the default.
+COV_TOL = 1e-8
+
 
 def cartcov():
     # Cartesian covariance matrix in m and m/s
@@ -164,7 +168,7 @@ class TestClassicalCartesian:
         classcov, tm = fc.covct2cl(cartcov, cartstate, use_mean_anom=use_mean_anom)
 
         # Compare results
-        assert custom_allclose(classcov, cov_expected)
+        assert custom_allclose(classcov, cov_expected, rtol=COV_TOL, atol=COV_TOL)
         assert custom_allclose(tm, tm_expected)
 
     @pytest.mark.parametrize(
@@ -390,7 +394,7 @@ class TestEquinoctialCartesian:
         eqcov, tm = fc.covct2eq(cartcov, cartstate, fr, use_mean_anom=use_mean_anom)
 
         # Compare results
-        assert custom_allclose(eqcov, np.array(cov_exp))
+        assert custom_allclose(eqcov, np.array(cov_exp), rtol=COV_TOL, atol=COV_TOL)
         assert custom_allclose(tm, np.array(tm_exp))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Getting more unexpected CI failures on unrelated branches/PRs, and here's another one.

## Changes

Update tolerances in covariance calcs for frame conversions to make them a bit looser.

## Testing

CI pipeline passing

- [x] All existing tests pass: `python -m pytest -v --disable-warnings tests/`
- [x] Black formatting passes: `black --check --skip-magic-trailing-comma .`
- [x] Flake8 linting passes: `flake8 --statistics .`

## Language(s) Affected

- [x] Python
- [ ] MATLAB
- [ ] C#
- [ ] C++
- [ ] Fortran
- [ ] Documentation only