### PR TITLE
bugfix: fix integer to string casting

### DIFF
--- a/software/cpp/SGP4/SGP4/SGP4.cpp
+++ b/software/cpp/SGP4/SGP4/SGP4.cpp
@@ -2248,7 +2248,7 @@ namespace SGP4Funcs
 
 		int strIndex, index;
 		if (isdigit(satrec.satnumStr[0]))
-			satrec.satnum = (int)(satrec.satnumStr);
+			satrec.satnum = std::atoi(satrec.satnumStr);
 		else
 		{
 			int alpha5[] = {10, 11, 12, 13, 14, 15, 16, 17, 0, 18, 19, 20, 21, 22, 0, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33};
@@ -2256,7 +2256,7 @@ namespace SGP4Funcs
 			index = alpha5[strIndex];
 			std::string s(satrec.satnumStr);
 			std::string sub = s.substr(1, 4);
-			satrec.satnum = index * 10000 + std::stoi(sub.substr(1, 4));
+			satrec.satnum = index * 10000 + std::stoi(sub);
 		}
 
 		// sgp4fix note that the ephtype must be 0 for SGP4. SGP4-XP uses 4.

--- a/software/cpp/SGP4/SGP4/SGP4.cpp
+++ b/software/cpp/SGP4/SGP4/SGP4.cpp
@@ -2248,7 +2248,7 @@ namespace SGP4Funcs
 
 		int strIndex, index;
 		if (isdigit(satrec.satnumStr[0]))
-			satrec.satnum = std::atoi(satrec.satnumStr);
+			satrec.satnum = std::stoi(std::string(satrec.satnumStr));
 		else
 		{
 			int alpha5[] = {10, 11, 12, 13, 14, 15, 16, 17, 0, 18, 19, 20, 21, 22, 0, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33};


### PR DESCRIPTION
## Summary

Fixes string to integer casting

Closes https://github.com/CelesTrak/fundamentals-of-astrodynamics/issues/163

## Changes

- Use `std::stoi(std::string(...))` for proper casting of `satrec.satnumStr` to an `int`
- Fix alpha-5 tail extraction: remove redundant `.substr(1, 4)` on `sub`, which already holds the 4-digit tail; the double-substring was silently dropping its leading digit  

## Language(s) Affected

- [ ] Python
- [ ] MATLAB
- [ ] C#
- [x] C++
- [ ] Fortran
- [ ] Documentation only
